### PR TITLE
Fix a abverb :all to :v

### DIFF
--- a/lib/Data/Section/Simple.pm6
+++ b/lib/Data/Section/Simple.pm6
@@ -16,7 +16,7 @@ method get-data-section(Str :$name, Str :$content) {
 }
 
 method !parse(Str :$name!, Str :$content!) {
-    my @data = $content.split(/^^ '@@' \s+ (.+?) \s* \r?\n/, :all);
+    my @data = $content.split(/^^ '@@' \s+ (.+?) \s* \r?\n/, :v);
     @data.shift;
     my %all = do for @data -> $/, $c {
         $/[0].Str => $c; # XXX


### PR DESCRIPTION
Hi
I changed an adverb of the split subroutine to pass the tests.
But sorry, I couldn't find `:all` abverb in both https://doc.perl6.org/routine/split  and https://github.com/perl6/roast/blob/master/S32-str/split.t pages, so I don't know what exactly `:all` adverb  is used for.
